### PR TITLE
Update Map.php

### DIFF
--- a/src/widgets/Map.php
+++ b/src/widgets/Map.php
@@ -94,7 +94,7 @@ class Map extends Widget
         $clientOptions = $this->leafLet->clientOptions;
 
         $options = empty($clientOptions) ? '{}' : Json::encode($clientOptions);
-        array_unshift($js, "var $name = L.map('$id', $options);");
+        array_unshift($js, " $name = L.map('$id', $options);");
         if ($this->leafLet->getTileLayer() !== null) {
             $js[] = $this->leafLet->getTileLayer()->encode();
         }


### PR DESCRIPTION
Initializing javascript variable without 'var', so that map variable is not local in scope and can be used by other javascript functions also.