### PR TITLE
Fix map load event

### DIFF
--- a/src/widgets/Map.php
+++ b/src/widgets/Map.php
@@ -93,6 +93,13 @@ class Map extends Widget
 
         $clientOptions = $this->leafLet->clientOptions;
 
+        // for map load event to fire, we have to postpone setting view, until events are bound
+        // see https://github.com/Leaflet/Leaflet/issues/3560
+        $lateInitClientOptions['center'] = Json::encode($clientOptions['center']);
+        $lateInitClientOptions['zoom'] = $clientOptions['zoom'];
+        unset($clientOptions['center']);
+        unset($clientOptions['zoom']);
+
         $options = empty($clientOptions) ? '{}' : Json::encode($clientOptions);
         array_unshift($js, "var $name = L.map('$id', $options);");
         if ($this->leafLet->getTileLayer() !== null) {
@@ -106,6 +113,9 @@ class Map extends Widget
                 $js[] = "$name.on('$event', $handler);";
             }
         }
+
+        $js[] = "$name.setView({$lateInitClientOptions['center']}, {$lateInitClientOptions['zoom']});";
+
         $view->registerJs("function {$name}_init(){\n" . implode("\n", $js) . "}\n{$name}_init();");
     }
 }

--- a/tests/functional/data/test-map-leaflet.bin
+++ b/tests/functional/data/test-map-leaflet.bin
@@ -11,12 +11,13 @@
 <script src="/2/jquery.js"></script>
 <script type="text/javascript">jQuery(document).ready(function () {
 function map_init(){
-var map = L.map('w0', {"center":[51.508,-0.11],"zoom":13});
+var map = L.map('w0', {});
 L.marker([51.508,-0.11], {}).bindPopup("Hi!").addTo(map);
 var test = L.TestPlugin();
 
 L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpeg', {"attribution":"Tiles Courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"http://developer.mapquest.com/content/osm/mq_logo.png\">, Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors, <a href=\"http://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA</a>","subdomains":"1234"}).addTo(map);
-map.on('click', function(e){ console.log(e); });}
+map.on('click', function(e){ console.log(e); });
+map.setView([51.508,-0.11], 13);}
 map_init();
 });</script></body>
 </html>

--- a/tests/functional/data/test-map-widget.bin
+++ b/tests/functional/data/test-map-widget.bin
@@ -10,10 +10,11 @@
 <script src="/1/jquery.js"></script>
 <script type="text/javascript">jQuery(document).ready(function () {
 function map_init(){
-var map = L.map('w1', {"center":[51.508,-0.11],"zoom":13});
+var map = L.map('w1', {});
 L.marker([51.508,-0.11], {}).bindPopup("Hi!").addTo(map);
 L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpeg', {"attribution":"Tiles Courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"http://developer.mapquest.com/content/osm/mq_logo.png\">, Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors, <a href=\"http://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA</a>","subdomains":"1234"}).addTo(map);
-map.on('click', function(e){ console.log(e); });}
+map.on('click', function(e){ console.log(e); });
+map.setView([51.508,-0.11], 13);}
 map_init();
 });</script></body>
 </html>


### PR DESCRIPTION
The load event function in config was not fired because it is fired on setting map zoom/location, and it was set before events binding section. However, postponing setting zoom/location after events are bound allows the code to execute.

See https://github.com/Leaflet/Leaflet/issues/3560