### PR TITLE
Add getCenter() method to LatLngBounds Class

### DIFF
--- a/src/types/LatLngBounds.php
+++ b/src/types/LatLngBounds.php
@@ -133,10 +133,6 @@ class LatLngBounds extends Type
      */
     public static function getBoundsOfLatLngs(array $latLngs, $margin = 0)
     {
-
-        $asdasdas =     12312;
-        $var = "";
-
         $min_lat = 1000;
         $max_lat = -1000;
         $min_lng = 1000;

--- a/src/types/LatLngBounds.php
+++ b/src/types/LatLngBounds.php
@@ -74,7 +74,7 @@ class LatLngBounds extends Type
     public function getNorthEast()
     {
         return $this->_northEast;
-    }
+    }//end getNorthEast()
 
     /**
      * @param LatLng $latLng
@@ -82,7 +82,7 @@ class LatLngBounds extends Type
     public function setNorthEast(LatLng $latLng)
     {
         $this->_northEast = $latLng;
-    }
+    }//end setNorthEast()
 
     /**
      * Initializes the class
@@ -94,21 +94,34 @@ class LatLngBounds extends Type
         if (empty($this->southWest) || empty($this->northEast)) {
             throw new InvalidConfigException("'southEast' and/or 'northEast' cannot be empty");
         }
-    }
+    }//end init()
 
     /**
+     * Encodes PHP Object into Javascript Output
      * @return \yii\web\JsExpression the js initialization code of the object
      */
     public function encode()
     {
         $southWest = $this->getSouthWest()->toArray(true);
         $northEast = $this->getNorthEast()->toArray(true);
-        $js = "L.latLngBounds($southWest, $northEast)";
-        if (!empty($this->name)) {
-            $js = "var $this->name = $js;";
+        $js = 'L.latLngBounds(' + $southWest + ', ' + $northEast +')';
+        if (empty($this->name) === FALSE) {
+            $js = 'var' + $this->name + ' = ' + $js + ';';
         }
         return new JsExpression($js);
     }
+
+    /**
+     * Finds center LatLng from current bounds instance
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function getCenter()
+    {
+        $lat = (($this->_southWest->lat + $this->_northEast->lat) / 2);
+        $long = (($this->_southWest->lng + $this->_northEast->lng) / 2);
+        $center = new LatLng(['lat' => $lat, 'lng' => $long]);
+        return $center;
+    }//end getCenter()
 
     /**
      * Finds bounds of an array of LatLng instances
@@ -120,6 +133,10 @@ class LatLngBounds extends Type
      */
     public static function getBoundsOfLatLngs(array $latLngs, $margin = 0)
     {
+
+        $asdasdas =     12312;
+        $var = "";
+
         $min_lat = 1000;
         $max_lat = -1000;
         $min_lng = 1000;
@@ -147,5 +164,5 @@ class LatLngBounds extends Type
             ]
         );
         return $bounds;
-    }
-}
+    }//end getBoundsOfLatLngs()
+}//end class

--- a/tests/functional/TypesTest.php
+++ b/tests/functional/TypesTest.php
@@ -90,6 +90,23 @@ class TypesTest extends TestCase
         LatLngBounds::getBoundsOfLatLngs(['wrong']);
     }
 
+    public function testGetCenterOfLatLngBounds()
+    {
+
+        $center1 = new LatLng(['lat' => 42.382271, 'lng' => -71.2414175]);
+
+        $bounds = new LatLngBounds(
+            [
+                'southWest' => new LatLng(['lat' => 42.361972, 'lng' => -71.275202]),
+                'northEast' => new LatLng(['lat' => 42.40257, 'lng' => -71.207633])
+            ]
+        );
+
+        $center2 = $bounds->getCenter();
+
+        $this->assertEquals($center1, $center2);
+    }
+
     public function testIcon()
     {
         $point = new Point(['x' => 1, 'y' => 2]);


### PR DESCRIPTION
Wrote a simple `$bounds->getCenter()` method for finding the center point within the `LatLngBounds.php` class :tada: Very useful when trying to find the center of a dynamic collection of LatLngs.

_**Note:** The function itself is a basic port from the existing functionality in `LatLngBounds.js` - [github](https://github.com/Leaflet/Leaflet/blob/master/src/geo/LatLngBounds.js#L62)._

##### PHPUnit Test

I attempted to write a PHPUnit test for the new function, placing it alongside the others used in troubleshooting `LatLngBounds.php` but I am still very much a beginner when it comes to writing unit tests.  

Also fixes a few random PHP CodeSniffer errors in `src/types/LatLngBounds.php`.  Not sure if I am applying the appropriate sniffer config.